### PR TITLE
Adding gradient accumulation and random cropping

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ python npy2ckpt.py /where/to/save/numpy/weights --save-dir=/where/to/save/ckpt/w
 
 To train the network, one can use the augmented PASCAL VOC 2012 dataset with <code>10582</code> images for training and <code>1449</code> images for validation.
 
-The training script allows to monitor the progress in the optimisation process using TensorBoard's image summary. Besides that, one can also exploit random scaling of the inputs during training as a means for data augmentation. For example, to train the model from scratch with random scale turned on, simply run:
+The training script allows to monitor the progress in the optimisation process using TensorBoard's image summary. Besides that, one can also exploit random scaling and mirroring of the inputs during training as a means for data augmentation. For example, to train the model from scratch with random scale and mirroring turned on, simply run:
 ```bash
-python train.py --random-scale
+python train.py --random-scale --random-mirror
 ```
 
 <img src="images/summary.png"></img>

--- a/deeplab_resnet/image_reader.py
+++ b/deeplab_resnet/image_reader.py
@@ -5,6 +5,69 @@ import tensorflow as tf
 
 IMG_MEAN = np.array((104.00698793,116.66876762,122.67891434), dtype=np.float32)
 
+def image_scaling(img, label):
+    """
+    Randomly scales the images between 0.5 to 1.5 times the original size
+
+    Args:
+      img: Training image to scale
+      label: Segmentation mask to scale
+    """
+    
+    scale = tf.random_uniform([1], minval=0.5, maxval=1.5, dtype=tf.float32, seed=None)
+    h_new = tf.to_int32(tf.mul(tf.to_float(tf.shape(img)[0]), scale))
+    w_new = tf.to_int32(tf.mul(tf.to_float(tf.shape(img)[1]), scale))
+    new_shape = tf.squeeze(tf.pack([h_new, w_new]), squeeze_dims=[1])
+    img = tf.image.resize_images(img, new_shape)
+    label = tf.image.resize_nearest_neighbor(tf.expand_dims(label, 0), new_shape)
+    label = tf.squeeze(label, squeeze_dims=[0])
+   
+    return img, label
+
+def image_mirroring(image, random_number):
+    """
+    Randomly mirrors the images
+
+    Args:
+      img: Training image to scale
+      random_number: A random number
+    """
+    
+    distort_left_right_random = random_number[0]
+    mirror = tf.less(tf.pack([1.0, distort_left_right_random, 1.0]), 0.5)
+    image = tf.reverse(image, mirror)
+    return image
+
+def random_crop_and_pad_image_and_labels(image, label, crop_h, crop_w, ignore_label):
+    """
+    Randomly crop and pads the input images
+
+    Args:
+      img: Training image to crop/ pad
+      label: Segmentation mask to crop/ pad
+      crop_h: Height of cropped segment
+      crop_w: Width of cropped segment
+    """
+
+    label = tf.cast(label, dtype=tf.float32)
+    label = label - ignore_label # Needs to be subtracted and later added due to 0 padding
+    combined = tf.concat(2, [image, label]) 
+    image_shape = tf.shape(image)
+    combined_pad = tf.image.pad_to_bounding_box(combined, 0, 0, tf.maximum(crop_h, image_shape[0]), tf.maximum(crop_w, image_shape[1]))
+    
+    last_image_dim = tf.shape(image)[-1]
+    last_label_dim = tf.shape(label)[-1]
+    combined_crop = tf.random_crop(combined_pad, [crop_h,crop_w,4])
+    img_crop = combined_crop[:, :, :last_image_dim]
+    label_crop = combined_crop[:, :, last_image_dim:]
+    label_crop = label_crop + ignore_label
+    label_crop = tf.cast(label_crop, dtype=tf.uint8)
+    
+    # Set static shape so that tensorflow knows shape at compile time 
+    img_crop.set_shape((crop_h, crop_w, 3))
+    label_crop.set_shape((crop_h,crop_w, 1))
+    return img_crop, label_crop  
+
 def read_labeled_image_list(data_dir, data_list):
     """Reads txt file containing paths to images and ground truth masks.
     
@@ -27,7 +90,7 @@ def read_labeled_image_list(data_dir, data_list):
         masks.append(data_dir + mask)
     return images, masks
 
-def read_images_from_disk(input_queue, input_size, random_scale): # optional pre-processing arguments
+def read_images_from_disk(input_queue, input_size, random_scale, random_mirror): # optional pre-processing arguments
     """Read one image and its corresponding mask with optional pre-processing.
     
     Args:
@@ -36,10 +99,13 @@ def read_images_from_disk(input_queue, input_size, random_scale): # optional pre
                   If not given, return images of original size.
       random_scale: whether to randomly scale the images prior
                     to random crop.
+      random_mirror: whether to randomly mirror the images prior
+                    to random crop.
       
     Returns:
       Two tensors: the decoded image and its mask.
     """
+
     img_contents = tf.read_file(input_queue[0])
     label_contents = tf.read_file(input_queue[1])
     
@@ -47,21 +113,26 @@ def read_images_from_disk(input_queue, input_size, random_scale): # optional pre
     img_r, img_g, img_b = tf.split(split_dim=2, num_split=3, value=img)
     img = tf.cast(tf.concat(2, [img_b, img_g, img_r]), dtype=tf.float32)
     # extract mean
-    img -= IMG_MEAN 
+    img -= IMG_MEAN
+
     label = tf.image.decode_png(label_contents, channels=1)
+
     if input_size is not None:
         h, w = input_size
-        if random_scale:
-            scale = tf.random_uniform([1], minval=0.75, maxval=1.25, dtype=tf.float32, seed=None)
-            h_new = tf.to_int32(tf.mul(tf.to_float(tf.shape(img)[0]), scale))
-            w_new = tf.to_int32(tf.mul(tf.to_float(tf.shape(img)[1]), scale))
-            new_shape = tf.squeeze(tf.pack([h_new, w_new]), squeeze_dims=[1])
 
-            img = tf.image.resize_images(img, new_shape)
-            label = tf.image.resize_nearest_neighbor(tf.expand_dims(label, 0), new_shape)
-            label = tf.squeeze(label, squeeze_dims=[0])
-        img = tf.image.resize_image_with_crop_or_pad(img, h, w)
-        label = tf.image.resize_image_with_crop_or_pad(label, h, w)
+        # Randomly scale the images and labels
+        if random_scale:
+            img, label = image_scaling(img, label)
+
+        # Randomly mirror the images and labels
+        if random_mirror:
+            random_number = tf.random_uniform([2], 0, 1.0, dtype=tf.float32)
+            img = image_mirroring(img, random_number)
+            label = image_mirroring(label, random_number)
+
+        # Randomly crops the images and labels
+        img, label = random_crop_and_pad_image_and_labels(img, label, h, w, 255)
+
     return img, label
 
 class ImageReader(object):
@@ -69,7 +140,8 @@ class ImageReader(object):
        masks from the disk, and enqueues them into a TensorFlow queue.
     '''
 
-    def __init__(self, data_dir, data_list, input_size, random_scale, coord):
+    def __init__(self, data_dir, data_list, input_size, random_scale,
+                 random_mirror, coord):
         '''Initialise an ImageReader.
         
         Args:
@@ -77,6 +149,7 @@ class ImageReader(object):
           data_list: path to the file with lines of the form '/path/to/image /path/to/mask'.
           input_size: a tuple with (height, width) values, to which all the images will be resized.
           random_scale: whether to randomly scale the images prior to random crop.
+          random_mirror: whether to randomly mirror the images prior to random crop.
           coord: TensorFlow queue coordinator.
         '''
         self.data_dir = data_dir
@@ -89,7 +162,7 @@ class ImageReader(object):
         self.labels = tf.convert_to_tensor(self.label_list, dtype=tf.string)
         self.queue = tf.train.slice_input_producer([self.images, self.labels],
                                                    shuffle=input_size is not None) # not shuffling if it is val
-        self.image, self.label = read_images_from_disk(self.queue, self.input_size, random_scale) 
+        self.image, self.label = read_images_from_disk(self.queue, self.input_size, random_scale, random_mirror) 
 
     def dequeue(self, num_elements):
         '''Pack images and labels into a batch.

--- a/evaluate.py
+++ b/evaluate.py
@@ -66,6 +66,7 @@ def main():
             args.data_list,
             None, # No defined input size.
             False, # No random scale.
+            False, # No random mirror
             coord)
         image, label = reader.image, reader.label
     image_batch, label_batch = tf.expand_dims(image, dim=0), tf.expand_dims(label, dim=0) # Add one batch dimension.

--- a/fine_tune.py
+++ b/fine_tune.py
@@ -55,6 +55,8 @@ def get_arguments():
                         help="Number of training steps.")
     parser.add_argument("--random-scale", action="store_true",
                         help="Whether to randomly scale the inputs during the training.")
+    parser.add_argument("--random-mirror", action="store_true",
+                        help="Whether to randomly mirror the inputs during the training.")
     parser.add_argument("--restore-from", type=str, default=RESTORE_FROM,
                         help="Where restore model parameters from.")
     parser.add_argument("--save-num-images", type=int, default=SAVE_NUM_IMAGES,
@@ -103,6 +105,7 @@ def main():
             args.data_list,
             input_size,
             args.random_scale,
+            args.random_mirror,
             coord)
         image_batch, label_batch = reader.dequeue(args.batch_size)
     

--- a/train.py
+++ b/train.py
@@ -62,6 +62,8 @@ def get_arguments():
                         help="Decay parameter to compute the learning rate.")
     parser.add_argument("--random-scale", action="store_true",
                         help="Whether to randomly scale the inputs during the training.")
+    parser.add_argument("--random-mirror", action="store_true",
+                        help="Whether to randomly mirror the inputs during the training.")
     parser.add_argument("--restore-from", type=str, default=RESTORE_FROM,
                         help="Where restore model parameters from.")
     parser.add_argument("--save-num-images", type=int, default=SAVE_NUM_IMAGES,
@@ -119,6 +121,7 @@ def main():
             args.data_list,
             input_size,
             args.random_scale,
+            args.random_mirror,
             coord)
         image_batch, label_batch = reader.dequeue(args.batch_size)
     
@@ -172,7 +175,8 @@ def main():
     total_summary = tf.summary.image('images', 
                                      tf.concat(2, [images_summary, labels_summary, preds_summary]), 
                                      max_outputs=args.save_num_images) # Concatenate row-wise.
-    summary_writer = tf.summary.FileWriter(args.snapshot_dir)
+    summary_writer = tf.summary.FileWriter(args.snapshot_dir,
+                                           graph=tf.get_default_graph())
    
     # Define loss and optimisation parameters.
     base_lr = tf.constant(args.learning_rate)

--- a/train_msc.py
+++ b/train_msc.py
@@ -20,7 +20,8 @@ from deeplab_resnet import DeepLabResNetModel, ImageReader, decode_labels, inv_p
 
 n_classes = 21
 
-BATCH_SIZE = 10
+BATCH_SIZE = 1
+GRAD_UPDATE_EVERY = 10
 DATA_DIRECTORY = '/home/VOCdevkit'
 DATA_LIST_PATH = './dataset/train.txt'
 INPUT_SIZE = '321,321'
@@ -29,7 +30,7 @@ MOMENTUM = 0.9
 NUM_STEPS = 20001
 POWER = 0.9
 RESTORE_FROM = './deeplab_resnet.ckpt'
-SAVE_NUM_IMAGES = 2
+SAVE_NUM_IMAGES = 1
 SAVE_PRED_EVERY = 1000
 SNAPSHOT_DIR = './snapshots/'
 WEIGHT_DECAY = 0.0005
@@ -44,6 +45,8 @@ def get_arguments():
     parser = argparse.ArgumentParser(description="DeepLab-ResNet Network")
     parser.add_argument("--batch-size", type=int, default=BATCH_SIZE,
                         help="Number of images sent to the network in one step.")
+    parser.add_argument("--grad-update-every", type=int, default=GRAD_UPDATE_EVERY,
+                        help="Number of steps after which gradient update is applied.")
     parser.add_argument("--data-dir", type=str, default=DATA_DIRECTORY,
                         help="Path to the directory containing the PASCAL VOC dataset.")
     parser.add_argument("--data-list", type=str, default=DATA_LIST_PATH,
@@ -62,6 +65,8 @@ def get_arguments():
                         help="Decay parameter to compute the learning rate.")
     parser.add_argument("--random-scale", action="store_true",
                         help="Whether to randomly scale the inputs during the training.")
+    parser.add_argument("--random-mirror", action="store_true",
+                        help="Whether to randomly mirror the inputs during the training.")
     parser.add_argument("--restore-from", type=str, default=RESTORE_FROM,
                         help="Where restore model parameters from.")
     parser.add_argument("--save-num-images", type=int, default=SAVE_NUM_IMAGES,
@@ -73,7 +78,6 @@ def get_arguments():
     parser.add_argument("--weight-decay", type=float, default=WEIGHT_DECAY,
                         help="Regularisation parameter for L2-loss.")
     return parser.parse_args()
-
 
 def save(saver, sess, logdir, step):
    '''Save weights.
@@ -120,6 +124,7 @@ def main():
             args.data_list,
             input_size,
             args.random_scale,
+            args.random_mirror,
             coord)
         image_batch, label_batch = reader.dequeue(args.batch_size)
         image_batch075 = tf.image.resize_images(image_batch, [int(h * 0.75), int(w * 0.75)])
@@ -207,7 +212,8 @@ def main():
     total_summary = tf.summary.image('images', 
                                      tf.concat(2, [images_summary, labels_summary, preds_summary]), 
                                      max_outputs=args.save_num_images) # Concatenate row-wise.
-    summary_writer = tf.summary.FileWriter(args.snapshot_dir)
+    summary_writer = tf.summary.FileWriter(args.snapshot_dir,
+                                           graph=tf.get_default_graph())
    
     # Define loss and optimisation parameters.
     base_lr = tf.constant(args.learning_rate)
@@ -218,11 +224,25 @@ def main():
     opt_fc_w = tf.train.MomentumOptimizer(learning_rate * 10.0, args.momentum)
     opt_fc_b = tf.train.MomentumOptimizer(learning_rate * 20.0, args.momentum)
 
-    grads = tf.gradients(reduced_loss, conv_trainable + fc_w_trainable + fc_b_trainable)
-    grads_conv = grads[:len(conv_trainable)]
-    grads_fc_w = grads[len(conv_trainable) : (len(conv_trainable) + len(fc_w_trainable))]
-    grads_fc_b = grads[(len(conv_trainable) + len(fc_w_trainable)):]
+    # Define a variable to accumulate gradients
+    accum_grads = [tf.Variable(tf.zeros_like(v.initialized_value()),
+                               trainable=False) for v in conv_trainable + fc_w_trainable + fc_b_trainable]
 
+    # Define an operation to clear the accumulated gradients for next batch
+    zero_op = [v.assign(tf.zeros_like(v)) for v in accum_grads]
+
+    # Compute gradients
+    grads = tf.gradients(reduced_loss, conv_trainable + fc_w_trainable + fc_b_trainable)
+
+    accum_grads_op = [accum_grads[i].assign_add(grad) for i, grad in
+                       enumerate(grads)]
+
+    # Normalize the gradients before applying
+    grads_conv = np.asarray(accum_grads[:len(conv_trainable)]) / args.grad_update_every
+    grads_fc_w = np.asarray(accum_grads[len(conv_trainable) : (len(conv_trainable) + len(fc_w_trainable))]) / args.grad_update_every 
+    grads_fc_b = np.asarray(accum_grads[(len(conv_trainable) + len(fc_w_trainable)):]) / args.grad_update_every
+
+    # Apply the gradients
     train_op_conv = opt_conv.apply_gradients(zip(grads_conv, conv_trainable))
     train_op_fc_w = opt_fc_w.apply_gradients(zip(grads_fc_w, fc_w_trainable))
     train_op_fc_b = opt_fc_b.apply_gradients(zip(grads_fc_b, fc_b_trainable))
@@ -253,13 +273,27 @@ def main():
     for step in range(args.num_steps):
         start_time = time.time()
         feed_dict = { step_ph : step }
-        
+        loss_value = 0
+
+        # Clear the accumulated gradients
+        sess.run(zero_op, feed_dict=feed_dict)
+       
+        # Accumulate gradients
+        for i in range(args.grad_update_every):
+            _, l_val = sess.run([accum_grads_op, reduced_loss], feed_dict=feed_dict)
+            loss_value += l_val
+
+        # Normalize the loss
+        loss_value /= args.grad_update_every
+
+        # Apply gradients
         if step % args.save_pred_every == 0:
-            loss_value, images, labels, preds, summary, _ = sess.run([reduced_loss, image_batch, label_batch, pred, total_summary, train_op], feed_dict=feed_dict)
+            images, labels, summary, _ = sess.run([image_batch, label_batch, total_summary, train_op], feed_dict=feed_dict)
             summary_writer.add_summary(summary, step)
             save(saver, sess, args.snapshot_dir, step)
         else:
-            loss_value, _ = sess.run([reduced_loss, train_op], feed_dict=feed_dict)
+            sess.run(train_op, feed_dict=feed_dict)
+
         duration = time.time() - start_time
         print('step {:d} \t loss = {:.3f}, ({:.3f} sec/step)'.format(step, loss_value, duration))
     coord.request_stop()


### PR DESCRIPTION
Summary: This commit adds gradient accumulation strategy where
the gardients are accumulated for 'X' number of steps before
updating the weights, effectively mimicing the "iter_size"
functionality of Caffe. This allows for arbitrary length batch
sizes on the GPUs with less memory. Also, random cropping and mirroring
is added as means for better data augmentation.

Signed-off-by: Arslan Chaudhry (arslan_mac@yahoo.com)