### PR TITLE
Support Python 3, Newer TensorFlow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+snapshots/
+*.ckpt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 snapshots/
+output/
+*.jpeg
 *.ckpt

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ In order to apply the same scripts using your own dataset, you would need to fol
 
 0. Make sure that your segmentation masks are in the same format as the ones in the DeepLab setup (i.e., without a colour map). This means that if your segmentation masks are RGB images, you would need to convert each 3-D RGB vector into a 1-D label. For example, take a look [here](https://gist.github.com/DrSleep/4bce37254c5900545e6b65f6a0858b9c);
 1. Create a file with instances of your dataset in the same format as in files [here](https://github.com/DrSleep/tensorflow-deeplab-resnet/tree/master/dataset);
-2. Change the flags `data-dir` and `data-list` accordingly in thehttps://gist.github.com/DrSleep/4bce37254c5900545e6b65f6a0858b9c); script file that you will be using (e.g., `python train.py --data-dir /my/data/dir --data-list /my/data/list`);
+2. Change the flags `data-dir` and `data-list` accordingly in [the script](https://gist.github.com/DrSleep/4bce37254c5900545e6b65f6a0858b9c) file that you will be using (e.g., `python train.py --data-dir /my/data/dir --data-list /my/data/list`);
 3. Change the `IMG_MEAN` vector accordingly in the script file that you will be using;
 4. For visualisation purposes, you will also need to change the colour map [here](https://github.com/DrSleep/tensorflow-deeplab-resnet/blob/master/deeplab_resnet/utils.py);
 5. Change the flags `num-classes` and `ignore-label` accordingly in the script that you will be using (e.g., `python train.py --ignore-label 255 --num-classes 21`).

--- a/evaluate.py
+++ b/evaluate.py
@@ -94,8 +94,14 @@ def main():
     # mIoU
     pred = tf.reshape(pred, [-1,])
     gt = tf.reshape(label_batch, [-1,])
-    weights = tf.cast(tf.less_equal(gt, args.num_classes - 1), tf.int32) # Ignoring all labels greater than or equal to n_classes.
-    mIoU, update_op = tf.contrib.metrics.streaming_mean_iou(pred, gt, num_classes=args.num_classes, weights=weights)
+    # https://github.com/DrSleep/tensorflow-deeplab-resnet/issues/107
+    # weights = tf.cast(tf.less_equal(gt, args.num_classes - 1), tf.int32) # Ignoring all labels greater than or equal to n_classes.
+    # mIoU, update_op = tf.contrib.metrics.streaming_mean_iou(pred, gt, num_classes=args.num_classes, weights=weights)
+    num_classes = args.num_classes
+    indices = tf.squeeze(tf.where(tf.less_equal(gt, num_classes - 1)), 1)  # ignore all labels >= num_classes
+    gt = tf.cast(tf.gather(gt, indices), tf.int32)
+    pred = tf.gather(pred, indices)
+    mIoU, update_op = tf.contrib.metrics.streaming_mean_iou(pred, gt, num_classes=num_classes)
 
     # Set up tf session and initialize variables.
     config = tf.ConfigProto()

--- a/inference.py
+++ b/inference.py
@@ -96,7 +96,9 @@ def main():
     if not os.path.exists(args.save_dir):
         os.makedirs(args.save_dir)
     im.save(args.save_dir + 'mask.png')
-    
+    im = Image.fromarray(preds[0, :, :, 0], 'L')
+    im.save(args.save_dir + 'preds.png')
+
     print('The output file has been saved to {}'.format(args.save_dir + 'mask.png'))
 
     

--- a/inference.py
+++ b/inference.py
@@ -19,13 +19,13 @@ import numpy as np
 from deeplab_resnet import DeepLabResNetModel, ImageReader, decode_labels, prepare_label
 
 IMG_MEAN = np.array((104.00698793,116.66876762,122.67891434), dtype=np.float32)
-    
+
 NUM_CLASSES = 21
 SAVE_DIR = './output/'
 
 def get_arguments():
     """Parse all the arguments provided from the CLI.
-    
+
     Returns:
       A list of parsed arguments.
     """
@@ -42,27 +42,27 @@ def get_arguments():
 
 def load(saver, sess, ckpt_path):
     '''Load trained weights.
-    
+
     Args:
       saver: TensorFlow saver object.
       sess: TensorFlow session.
       ckpt_path: path to checkpoint file with parameters.
-    ''' 
+    '''
     saver.restore(sess, ckpt_path)
     print("Restored model parameters from {}".format(ckpt_path))
 
 def main():
     """Create the model and start the evaluation process."""
     args = get_arguments()
-    
+
     # Prepare image.
     img = tf.image.decode_jpeg(tf.read_file(args.img_path), channels=3)
     # Convert RGB to BGR.
     img_r, img_g, img_b = tf.split(axis=2, num_or_size_splits=3, value=img)
     img = tf.cast(tf.concat(axis=2, values=[img_b, img_g, img_r]), dtype=tf.float32)
     # Extract mean.
-    img -= IMG_MEAN 
-    
+    img -= IMG_MEAN
+
     # Create network.
     net = DeepLabResNetModel({'data': tf.expand_dims(img, dim=0)}, is_training=False, num_classes=args.num_classes)
 
@@ -75,22 +75,22 @@ def main():
     raw_output_up = tf.argmax(raw_output_up, dimension=3)
     pred = tf.expand_dims(raw_output_up, dim=3)
 
-    
-    # Set up TF session and initialize variables. 
+
+    # Set up TF session and initialize variables.
     config = tf.ConfigProto()
     config.gpu_options.allow_growth = True
     sess = tf.Session(config=config)
     init = tf.global_variables_initializer()
-    
+
     sess.run(init)
-    
+
     # Load weights.
     loader = tf.train.Saver(var_list=restore_var)
     load(loader, sess, args.model_weights)
-    
+
     # Perform inference.
     preds = sess.run(pred)
-    
+
     msk = decode_labels(preds, num_classes=args.num_classes)
     im = Image.fromarray(msk[0])
     if not os.path.exists(args.save_dir):
@@ -101,6 +101,6 @@ def main():
 
     print('The output file has been saved to {}'.format(args.save_dir + 'mask.png'))
 
-    
+
 if __name__ == '__main__':
     main()

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -131,7 +131,7 @@ class Network(object):
         # Convolution for a given input and kernel
         convolve = lambda i, k: tf.nn.conv2d(i, k, [1, s_h, s_w, 1], padding=padding)
         with tf.variable_scope(name) as scope:
-            kernel = self.make_var('weights', shape=[k_h, k_w, c_i / group, c_o])
+            kernel = self.make_var('weights', shape=[k_h, k_w, c_i.value / group, c_o])
             if group == 1:
                 # This is the common-case. Convolve the input without any further complications.
                 output = convolve(input, kernel)
@@ -173,7 +173,7 @@ class Network(object):
         # Convolution for a given input and kernel
         convolve = lambda i, k: tf.nn.atrous_conv2d(i, k, dilation, padding=padding)
         with tf.variable_scope(name) as scope:
-            kernel = self.make_var('weights', shape=[k_h, k_w, c_i / group, c_o])
+            kernel = self.make_var('weights', shape=[k_h, k_w, c_i.value / group, c_o])
             if group == 1:
                 # This is the common-case. Convolve the input without any further complications.
                 output = convolve(input, kernel)

--- a/kaffe/tensorflow/network.py
+++ b/kaffe/tensorflow/network.py
@@ -5,6 +5,12 @@ slim = tf.contrib.slim
 DEFAULT_PADDING = 'SAME'
 
 
+try:
+  basestring
+except NameError:
+  basestring = str
+
+
 def layer(op):
     '''Decorator for composable network layers.'''
 
@@ -186,7 +192,7 @@ class Network(object):
                 # ReLU non-linearity
                 output = tf.nn.relu(output, name=scope.name)
             return output
-        
+
     @layer
     def relu(self, input, name):
         return tf.nn.relu(input, name=name)
@@ -256,7 +262,7 @@ class Network(object):
             else:
                 raise ValueError('Rank 2 tensor input expected for softmax!')
         return tf.nn.softmax(input, name)
-        
+
     @layer
     def batch_normalization(self, input, name, is_training, activation_fn=None, scale=True):
         with tf.variable_scope(name) as scope:

--- a/train.py
+++ b/train.py
@@ -40,7 +40,7 @@ WEIGHT_DECAY = 0.0005
 
 def get_arguments():
     """Parse all the arguments provided from the CLI.
-    
+
     Returns:
       A list of parsed arguments.
     """
@@ -89,7 +89,7 @@ def get_arguments():
 
 def save(saver, sess, logdir, step):
    '''Save weights.
-   
+
    Args:
      saver: TensorFlow Saver object.
      sess: TensorFlow session.
@@ -98,7 +98,7 @@ def save(saver, sess, logdir, step):
    '''
    model_name = 'model.ckpt'
    checkpoint_path = os.path.join(logdir, model_name)
-    
+
    if not os.path.exists(logdir):
       os.makedirs(logdir)
    saver.save(sess, checkpoint_path, global_step=step)
@@ -106,27 +106,27 @@ def save(saver, sess, logdir, step):
 
 def load(saver, sess, ckpt_path):
     '''Load trained weights.
-    
+
     Args:
       saver: TensorFlow Saver object.
       sess: TensorFlow session.
       ckpt_path: path to checkpoint file with parameters.
-    ''' 
+    '''
     saver.restore(sess, ckpt_path)
     print("Restored model parameters from {}".format(ckpt_path))
 
 def main():
     """Create the model and start the training."""
     args = get_arguments()
-    
+
     h, w = map(int, args.input_size.split(','))
     input_size = (h, w)
-    
+
     tf.set_random_seed(args.random_seed)
-    
+
     # Create queue coordinator.
     coord = tf.train.Coordinator()
-    
+
     # Load reader.
     with tf.name_scope("create_inputs"):
         reader = ImageReader(
@@ -139,12 +139,12 @@ def main():
             IMG_MEAN,
             coord)
         image_batch, label_batch = reader.dequeue(args.batch_size)
-    
+
     # Create network.
     net = DeepLabResNetModel({'data': image_batch}, is_training=args.is_training, num_classes=args.num_classes)
-    # For a small batch size, it is better to keep 
+    # For a small batch size, it is better to keep
     # the statistics of the BN layers (running means and variances)
-    # frozen, and to not update the values provided by the pre-trained model. 
+    # frozen, and to not update the values provided by the pre-trained model.
     # If is_training=True, the statistics will be updated during the training.
     # Note that is_training=False still updates BN parameters gamma (scale) and beta (offset)
     # if they are presented in var_list of the optimiser definition.
@@ -161,8 +161,8 @@ def main():
     fc_b_trainable = [v for v in fc_trainable if 'biases' in v.name] # lr * 20.0
     assert(len(all_trainable) == len(fc_trainable) + len(conv_trainable))
     assert(len(fc_trainable) == len(fc_w_trainable) + len(fc_b_trainable))
-    
-    
+
+
     # Predictions: ignoring all predictions with labels greater or equal than n_classes
     raw_prediction = tf.reshape(raw_output, [-1, args.num_classes])
     label_proc = prepare_label(label_batch, tf.stack(raw_output.get_shape()[1:3]), num_classes=args.num_classes, one_hot=False) # [batch_size, h, w]
@@ -170,34 +170,34 @@ def main():
     indices = tf.squeeze(tf.where(tf.less_equal(raw_gt, args.num_classes - 1)), 1)
     gt = tf.cast(tf.gather(raw_gt, indices), tf.int32)
     prediction = tf.gather(raw_prediction, indices)
-                                                  
-                                                  
+
+
     # Pixel-wise softmax loss.
     loss = tf.nn.sparse_softmax_cross_entropy_with_logits(logits=prediction, labels=gt)
     l2_losses = [args.weight_decay * tf.nn.l2_loss(v) for v in tf.trainable_variables() if 'weights' in v.name]
     reduced_loss = tf.reduce_mean(loss) + tf.add_n(l2_losses)
-    
+
     # Processed predictions: for visualisation.
     raw_output_up = tf.image.resize_bilinear(raw_output, tf.shape(image_batch)[1:3,])
     raw_output_up = tf.argmax(raw_output_up, dimension=3)
     pred = tf.expand_dims(raw_output_up, dim=3)
-    
+
     # Image summary.
     images_summary = tf.py_func(inv_preprocess, [image_batch, args.save_num_images, IMG_MEAN], tf.uint8)
     labels_summary = tf.py_func(decode_labels, [label_batch, args.save_num_images, args.num_classes], tf.uint8)
     preds_summary = tf.py_func(decode_labels, [pred, args.save_num_images, args.num_classes], tf.uint8)
-    
-    total_summary = tf.summary.image('images', 
-                                     tf.concat(axis=2, values=[images_summary, labels_summary, preds_summary]), 
+
+    total_summary = tf.summary.image('images',
+                                     tf.concat(axis=2, values=[images_summary, labels_summary, preds_summary]),
                                      max_outputs=args.save_num_images) # Concatenate row-wise.
     summary_writer = tf.summary.FileWriter(args.snapshot_dir,
                                            graph=tf.get_default_graph())
-   
+
     # Define loss and optimisation parameters.
     base_lr = tf.constant(args.learning_rate)
     step_ph = tf.placeholder(dtype=tf.float32, shape=())
     learning_rate = tf.scalar_mul(base_lr, tf.pow((1 - step_ph / args.num_steps), args.power))
-    
+
     opt_conv = tf.train.MomentumOptimizer(learning_rate, args.momentum)
     opt_fc_w = tf.train.MomentumOptimizer(learning_rate * 10.0, args.momentum)
     opt_fc_b = tf.train.MomentumOptimizer(learning_rate * 20.0, args.momentum)
@@ -212,24 +212,24 @@ def main():
     train_op_fc_b = opt_fc_b.apply_gradients(zip(grads_fc_b, fc_b_trainable))
 
     train_op = tf.group(train_op_conv, train_op_fc_w, train_op_fc_b)
-    
-    
-    # Set up tf session and initialize variables. 
+
+
+    # Set up tf session and initialize variables.
     config = tf.ConfigProto()
     config.gpu_options.allow_growth = True
     sess = tf.Session(config=config)
     init = tf.global_variables_initializer()
-    
+
     sess.run(init)
-    
+
     # Saver for storing checkpoints of the model.
     saver = tf.train.Saver(var_list=tf.global_variables(), max_to_keep=10)
-    
+
     # Load variables if the checkpoint is provided.
     if args.restore_from is not None:
         loader = tf.train.Saver(var_list=restore_var)
         load(loader, sess, args.restore_from)
-    
+
     # Start queue threads.
     threads = tf.train.start_queue_runners(coord=coord, sess=sess)
 
@@ -237,7 +237,7 @@ def main():
     for step in range(args.num_steps):
         start_time = time.time()
         feed_dict = { step_ph : step }
-        
+
         if step % args.save_pred_every == 0:
             loss_value, images, labels, preds, summary, _ = sess.run([reduced_loss, image_batch, label_batch, pred, total_summary, train_op], feed_dict=feed_dict)
             summary_writer.add_summary(summary, step)
@@ -248,6 +248,6 @@ def main():
         print('step {:d} \t loss = {:.3f}, ({:.3f} sec/step)'.format(step, loss_value, duration))
     coord.request_stop()
     coord.join(threads)
-    
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This changeset does a few things.  It
   - [Adds support for Python 3](https://github.com/jamesmcclain/tensorflow-deeplab-resnet/commit/63a01f1420abeb23faf2e91e203e61e1ae21533b).  Python 2 should still continue to work as before.
   - [Adds support for newer TensorFlow versions](https://github.com/jamesmcclain/tensorflow-deeplab-resnet/commit/c66c42f6d497b42e75fdd12d1a64a4006b111c7d).  This change is not compatible with older versions.  That can be changed in a subsequent commit if there is interest.
   - [Addresses a minor typo in the README](https://github.com/jamesmcclain/tensorflow-deeplab-resnet/commit/5e1d3032e59e63dd591e337af6017c34c55b092b).

`train.py`, `evaluate.py`, and `inference.py` all appear to work on top of the `tensorflow/tensorflow:1.12.0-rc0-gpu-py3` docker image with these changes.
